### PR TITLE
JENKINS-67134 NullPointerException in ToolEnvBuildWrapper

### DIFF
--- a/src/main/java/hudson/plugins/toolenv/ToolEnvBuildWrapper.java
+++ b/src/main/java/hudson/plugins/toolenv/ToolEnvBuildWrapper.java
@@ -44,7 +44,12 @@ public class ToolEnvBuildWrapper extends BuildWrapper {
                     }
                     if (tool instanceof NodeSpecific) {
                         try {
-                            Node node = Computer.currentComputer().getNode();
+                            Computer computer = Computer.currentComputer();
+                            if (computer == null) {
+                                listener.error("Could not install " + var + ". Computer is null.");
+                                continue;
+                            }
+                            Node node = computer.getNode();
                             if (node == null) {
                                 listener.error("Could not install " + var + ". Node is null.");
                                 continue;


### PR DESCRIPTION
We have the following exception stack trace at the end of each build:

```java
10:31:35 ERROR: Could not install JDK_11_HOME
10:31:35 java.lang.NullPointerException
10:31:35 	at hudson.plugins.toolenv.ToolEnvBuildWrapper$1.buildEnvVars(ToolEnvBuildWrapper.java:47)
10:31:35 	at hudson.model.AbstractBuild.getEnvironment(AbstractBuild.java:957)
10:31:35 	at com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.ParameterExpander.expandParameters(ParameterExpander.java:266)
10:31:35 	at com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.ParameterExpander.getBuildCompletedCommand(ParameterExpander.java:561)
10:31:35 	at com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.ParameterExpander.getBuildCompletedMessage(ParameterExpander.java:680)
10:31:35 	at com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.job.rest.BuildCompletedRestCommandJob.createReview(BuildCompletedRestCommandJob.java:81)
10:31:35 	at com.sonymobile.tools.gerrit.gerritevents.workers.rest.AbstractRestCommandJob.run(AbstractRestCommandJob.java:94)
10:31:35 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
10:31:35 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
10:31:35 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
10:31:35 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
10:31:35 	at java.base/java.lang.Thread.run(Thread.java:829)
```

Please note that this does not fail the build. It only clutters the logs.

I think `Computer.currentComputer()` returns null. 
With this PR, `Computer.currentComputer()` will be checked for nullity.